### PR TITLE
커스텀 예외 처리 구현

### DIFF
--- a/src/main/java/net/skhu/wassup/app/admin/service/AdminServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/admin/service/AdminServiceImpl.java
@@ -1,15 +1,20 @@
 package net.skhu.wassup.app.admin.service;
 
+import static net.skhu.wassup.global.error.ErrorCode.NOT_FOUND_ADMIN;
+import static net.skhu.wassup.global.error.ErrorCode.NOT_MATCH_ACCOUNT_ID_OR_PASSWORD;
+import static net.skhu.wassup.global.error.ErrorCode.NOT_MATCH_CERTIFICATION_CODE;
+
 import lombok.RequiredArgsConstructor;
 import net.skhu.wassup.app.admin.api.dto.RequestLogin;
+import net.skhu.wassup.app.admin.api.dto.RequestSignup;
 import net.skhu.wassup.app.admin.api.dto.ResponseAdmin;
 import net.skhu.wassup.app.admin.api.dto.ResponseLogin;
 import net.skhu.wassup.app.admin.domain.Admin;
 import net.skhu.wassup.app.admin.domain.AdminRepository;
-import net.skhu.wassup.app.admin.api.dto.RequestSignup;
 import net.skhu.wassup.app.certification.CertificationCodeService;
 import net.skhu.wassup.app.encryption.EncryptionService;
 import net.skhu.wassup.global.auth.jwt.TokenProvider;
+import net.skhu.wassup.global.error.exception.CustomException;
 import net.skhu.wassup.global.message.SMSMessageSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,8 +50,10 @@ public class AdminServiceImpl implements AdminService {
         String certificationCode = certificationCodeService.getCertificationCode(phoneNumber);
 
         if (!ObjectUtils.nullSafeEquals(certificationCode, inputCode)) {
-            throw new IllegalArgumentException("인증번호가 일치하지 않습니다.");
+            throw new CustomException(NOT_MATCH_CERTIFICATION_CODE);
         }
+
+        certificationCodeService.deleteCertificationCode(phoneNumber);
 
         return true;
     }
@@ -66,14 +73,10 @@ public class AdminServiceImpl implements AdminService {
 
     private Admin findCertificatedAdmin(RequestLogin requestLogin) {
         Admin admin = adminRepository.findByAdminId(requestLogin.adminId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));
-
-        if (ObjectUtils.isEmpty(admin)) {
-            throw new IllegalArgumentException("존재하지 않는 아이디입니다.");
-        }
+                .orElseThrow(() -> new CustomException(NOT_MATCH_ACCOUNT_ID_OR_PASSWORD));
 
         if (!encryptionService.isMatch(requestLogin.password(), admin.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new CustomException(NOT_MATCH_ACCOUNT_ID_OR_PASSWORD);
         }
 
         return admin;
@@ -99,7 +102,7 @@ public class AdminServiceImpl implements AdminService {
     @Transactional(readOnly = true)
     public ResponseAdmin getAdmin(Long id) {
         Admin admin = adminRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 관리자입니다."));
+                .orElseThrow(() -> new CustomException(NOT_FOUND_ADMIN));
 
         return ResponseAdmin.builder()
                 .id(admin.getId())

--- a/src/main/java/net/skhu/wassup/global/error/ErrorCode.java
+++ b/src/main/java/net/skhu/wassup/global/error/ErrorCode.java
@@ -1,0 +1,28 @@
+package net.skhu.wassup.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    NOT_MATCH_CERTIFICATION_CODE(HttpStatus.BAD_REQUEST, "NM001", "인증번호가 일치하지 않습니다."),
+    NOT_MATCH_ACCOUNT_ID_OR_PASSWORD(HttpStatus.BAD_REQUEST, "NM002", "아이디나 비밀번호가 일치하지 않습니다."),
+
+    NOT_FOUND_ADMIN(HttpStatus.NOT_FOUND, "NF001", "존재하지 않는 관리자입니다."),
+    NOT_FOUND_GROUP(HttpStatus.NOT_FOUND, "NF002", "그룹 정보가 존재하지 않습니다."),
+
+    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "IV001", "이메일 형식이 올바르지 않습니다."),
+
+    UNAUTHORIZED_ADMIN(HttpStatus.UNAUTHORIZED, "UU001", "권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String code;
+
+    private final String message;
+
+
+}

--- a/src/main/java/net/skhu/wassup/global/error/exception/CustomException.java
+++ b/src/main/java/net/skhu/wassup/global/error/exception/CustomException.java
@@ -1,0 +1,11 @@
+package net.skhu.wassup.global.error.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.skhu.wassup.global.error.ErrorCode;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    ErrorCode errorCode;
+}

--- a/src/main/java/net/skhu/wassup/global/error/handler/CustomExceptionHandler.java
+++ b/src/main/java/net/skhu/wassup/global/error/handler/CustomExceptionHandler.java
@@ -1,0 +1,17 @@
+package net.skhu.wassup.global.error.handler;
+
+import net.skhu.wassup.global.error.exception.CustomException;
+import net.skhu.wassup.global.error.response.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e){
+        return ErrorResponse.toResponseEntity(e.getErrorCode());
+    }
+
+}

--- a/src/main/java/net/skhu/wassup/global/error/response/ErrorResponse.java
+++ b/src/main/java/net/skhu/wassup/global/error/response/ErrorResponse.java
@@ -1,0 +1,31 @@
+package net.skhu.wassup.global.error.response;
+
+import lombok.Builder;
+import lombok.Data;
+import net.skhu.wassup.global.error.ErrorCode;
+import org.springframework.http.ResponseEntity;
+
+@Data
+@Builder
+public class ErrorResponse {
+
+    private final int status;
+
+    private final String name;
+
+    private final String code;
+
+    private final String message;
+
+    public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode e) {
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(ErrorResponse.builder()
+                        .status(e.getHttpStatus().value())
+                        .name(e.name())
+                        .code(e.getCode())
+                        .message(e.getMessage())
+                        .build()
+                );
+    }
+}


### PR DESCRIPTION
## 내용
- #24 

### 커스텀 예외를 사용한 이유
1. 기존의 제공해주는 예외를 사용할 수도 있지만, 커스텀 예외를 사용하면 더 상세한 예외 정보를 전달할 수 있습니다.
2. `HttpStatus`를 메세지와 함께 전달할 수 있습니다.
3. `Enum`클래스로 `ErrorCode`에 각 예외에 대한 메세지를 한 곳에 모아두어 응집도를 높일 수 있습니다.
4. `@ControllerAdvice` 어노테이션을 이용하여 예외를 핸들링하여 자세한 후처리를 하였습니다.