### PR TITLE
[close #23] 그룹 관련 기능 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/net/skhu/wassup/app/admin/api/AdminController.java
+++ b/src/main/java/net/skhu/wassup/app/admin/api/AdminController.java
@@ -88,4 +88,5 @@ public class AdminController {
         Long id = Long.parseLong(principal.getName());
         return ResponseEntity.status(OK).body(adminService.getAdmin(id));
     }
+
 }

--- a/src/main/java/net/skhu/wassup/app/admin/api/dto/RequestSignup.java
+++ b/src/main/java/net/skhu/wassup/app/admin/api/dto/RequestSignup.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "회원가입 요청")
 public record RequestSignup(
+
         @Schema(description = "아이디를 5자 이상 20자 이하로 입력해주세요.")
         @NotBlank(message = "아이디를 입력해주세요.")
         @Size(min = 5, max = 20, message = "아이디는 5자 이상 20자 이하로 입력해주세요.")

--- a/src/main/java/net/skhu/wassup/app/admin/api/dto/ResponseLogin.java
+++ b/src/main/java/net/skhu/wassup/app/admin/api/dto/ResponseLogin.java
@@ -3,7 +3,5 @@ package net.skhu.wassup.app.admin.api.dto;
 import lombok.Builder;
 
 @Builder
-public record ResponseLogin(
-        String token) {
-
+public record ResponseLogin(String token) {
 }

--- a/src/main/java/net/skhu/wassup/app/admin/domain/Admin.java
+++ b/src/main/java/net/skhu/wassup/app/admin/domain/Admin.java
@@ -1,6 +1,7 @@
 package net.skhu.wassup.app.admin.domain;
 
 import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -43,7 +44,7 @@ public class Admin extends BaseTimeEntity {
     private String phoneNumber;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "admin", cascade = REMOVE)
+    @OneToMany(mappedBy = "admin", cascade = REMOVE, fetch = EAGER)
     private List<Group> groups;
 
     @Builder

--- a/src/main/java/net/skhu/wassup/app/group/api/GroupController.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/GroupController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
 import java.util.List;
@@ -12,6 +13,7 @@ import net.skhu.wassup.app.group.api.dto.RequestGroup;
 import net.skhu.wassup.app.group.api.dto.RequestUpdateGroup;
 import net.skhu.wassup.app.group.api.dto.RequestVerify;
 import net.skhu.wassup.app.group.api.dto.ResponseGroup;
+import net.skhu.wassup.app.group.api.dto.ResponseMyGroup;
 import net.skhu.wassup.app.group.service.GroupService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -77,6 +79,7 @@ public class GroupController {
             summary = "그룹 정보 조회",
             description = "그룹 정보를 조회합니다."
     )
+    @Parameter(name = "id", description = "그룹 ID", required = true)
     public ResponseEntity<ResponseGroup> getGroup(@RequestParam Long id) {
         return ResponseEntity.status(OK).body(groupService.getGroup(id));
     }
@@ -86,7 +89,7 @@ public class GroupController {
             summary = "내 그룹 정보 조회",
             description = "내 그룹 정보를 조회합니다."
     )
-    public ResponseEntity<List<ResponseGroup>> getMyGroup(Principal principal) {
+    public ResponseEntity<List<ResponseMyGroup>> getMyGroup(Principal principal) {
         Long id = Long.parseLong(principal.getName());
         return ResponseEntity.status(OK).body(groupService.getMyGroup(id));
     }
@@ -96,9 +99,10 @@ public class GroupController {
             summary = "그룹 정보 수정",
             description = "그룹 정보를 수정합니다."
     )
+    @Parameter(name = "id", description = "그룹 ID", required = true)
     public ResponseEntity<Void> updateGroup(Principal principal,
-                                                     @RequestBody RequestUpdateGroup requestUpdateGroup,
-                                                     @RequestParam Long id) {
+                                            @RequestBody RequestUpdateGroup requestUpdateGroup,
+                                            @RequestParam Long id) {
         Long adminId = Long.parseLong(principal.getName());
         groupService.updateGroup(adminId, requestUpdateGroup, id);
         return ResponseEntity.status(OK).build();
@@ -109,6 +113,7 @@ public class GroupController {
             summary = "그룹 삭제",
             description = "그룹을 삭제합니다."
     )
+    @Parameter(name = "id", description = "그룹 ID", required = true)
     public ResponseEntity<Void> deleteGroup(Principal principal, @RequestParam Long id) {
         Long adminId = Long.parseLong(principal.getName());
         groupService.deleteGroup(adminId, id);

--- a/src/main/java/net/skhu/wassup/app/group/api/GroupInviteController.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/GroupInviteController.java
@@ -2,6 +2,8 @@ package net.skhu.wassup.app.group.api;
 
 import static org.springframework.http.HttpStatus.OK;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,11 @@ public class GroupInviteController {
     private final GroupInviteService groupInviteService;
 
     @PostMapping("send")
+    @Operation(
+            summary = "그룹 초대",
+            description = "그룹 초대를 진행합니다."
+    )
+    @Parameter(name = "id", description = "그룹 ID", required = true)
     public ResponseEntity<Void> send(Long id, @RequestBody RequestInviteGroup requestInviteGroup) {
         groupInviteService.send(id, requestInviteGroup);
 
@@ -30,6 +37,11 @@ public class GroupInviteController {
     }
 
     @PostMapping("accept")
+    @Operation(
+            summary = "그룹 초대 수락",
+            description = "그룹 초대를 수락합니다."
+    )
+    @Parameter(name = "id", description = "멤버 ID", required = true)
     public ResponseEntity<Void> accept(Principal principal, @RequestParam Long id) {
         Long adminId = Long.parseLong(principal.getName());
         groupInviteService.accept(adminId, id);
@@ -38,6 +50,11 @@ public class GroupInviteController {
     }
 
     @PostMapping("reject")
+    @Operation(
+            summary = "그룹 초대 거절",
+            description = "그룹 초대를 거절합니다."
+    )
+    @Parameter(name = "id", description = "멤버 ID", required = true)
     public ResponseEntity<Void> reject(Principal principal, @RequestParam Long id) {
         Long adminId = Long.parseLong(principal.getName());
         groupInviteService.reject(adminId, id);

--- a/src/main/java/net/skhu/wassup/app/group/api/dto/RequestUpdateGroup.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/dto/RequestUpdateGroup.java
@@ -1,24 +1,20 @@
 package net.skhu.wassup.app.group.api.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "그룹 수정 요청")
 public record RequestUpdateGroup(
 
         @Schema(description = "그룹 설명")
-        @NotBlank(message = "그룹을 설명해주세요.")
         String description,
 
         @Schema(description = "그룹 주소")
-        @NotBlank(message = "그룹 주소를 입력해주세요.")
         String address,
 
         @Schema(description = "사업자 번호")
         String businessNumber,
 
         @Schema(description = "그룹 이미지 URL")
-        @NotBlank(message = "그룹 이미지 URL을 입력해주세요.")
         String imageUrl) {
 
 }

--- a/src/main/java/net/skhu/wassup/app/group/api/dto/ResponseGroup.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/dto/ResponseGroup.java
@@ -23,6 +23,12 @@ public record ResponseGroup(
         String email,
 
         @Schema(description = "그룹 이미지 URL")
-        String imageUrl) {
+        String imageUrl,
+
+        @Schema(description = "총인원")
+        int totalMember,
+
+        @Schema(description = "가입대기중인 인원")
+        int waitingMember) {
 
 }

--- a/src/main/java/net/skhu/wassup/app/group/api/dto/ResponseMyGroup.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/dto/ResponseMyGroup.java
@@ -1,0 +1,25 @@
+package net.skhu.wassup.app.group.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "내 그룹 조회")
+public record ResponseMyGroup(
+
+        @Schema(description = "그룹 이름")
+        String groupName,
+
+        @Schema(description = "그룹 주소")
+        String address,
+
+        @Schema(description = "총 인원")
+        int totalMember,
+
+        @Schema(description = "가입 대기중인 인원")
+        int waitingMember,
+
+        @Schema(description = "그룹 이미지 URL")
+        String imageUrl) {
+
+}

--- a/src/main/java/net/skhu/wassup/app/group/domain/Group.java
+++ b/src/main/java/net/skhu/wassup/app/group/domain/Group.java
@@ -63,10 +63,10 @@ public class Group extends BaseTimeEntity {
     private List<Member> members;
 
     public void update(RequestUpdateGroup requestUpdateGroup) {
-        this.description = requestUpdateGroup.description();
-        this.address = requestUpdateGroup.address();
-        this.businessNumber = requestUpdateGroup.businessNumber();
-        this.imageUrl = requestUpdateGroup.imageUrl();
+        this.description = (requestUpdateGroup.description() != null) ? requestUpdateGroup.description() : this.description;
+        this.address = (requestUpdateGroup.address() != null) ? requestUpdateGroup.address() : this.address;
+        this.businessNumber = (requestUpdateGroup.businessNumber() != null) ? requestUpdateGroup.businessNumber() : this.businessNumber;
+        this.imageUrl = (requestUpdateGroup.imageUrl() != null) ? requestUpdateGroup.imageUrl() : this.imageUrl;
     }
 
     @Builder

--- a/src/main/java/net/skhu/wassup/app/group/domain/Group.java
+++ b/src/main/java/net/skhu/wassup/app/group/domain/Group.java
@@ -1,5 +1,6 @@
 package net.skhu.wassup.app.group.domain;
 
+import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -59,7 +60,7 @@ public class Group extends BaseTimeEntity {
     private String uniqueCode;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "group")
+    @OneToMany(mappedBy = "group", fetch = EAGER)
     private List<Member> members;
 
     public void update(RequestUpdateGroup requestUpdateGroup) {

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupInviteServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupInviteServiceImpl.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import net.skhu.wassup.app.group.api.dto.RequestInviteGroup;
 import net.skhu.wassup.app.group.domain.Group;
 import net.skhu.wassup.app.group.domain.GroupRepository;
-import net.skhu.wassup.app.member.domain.JoinStatus;
 import net.skhu.wassup.app.member.domain.Member;
 import net.skhu.wassup.app.member.domain.MemberRepository;
 import net.skhu.wassup.global.error.ErrorCode;

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupService.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import net.skhu.wassup.app.group.api.dto.RequestGroup;
 import net.skhu.wassup.app.group.api.dto.RequestUpdateGroup;
 import net.skhu.wassup.app.group.api.dto.ResponseGroup;
+import net.skhu.wassup.app.group.api.dto.ResponseMyGroup;
 
 public interface GroupService {
 
@@ -17,7 +18,7 @@ public interface GroupService {
 
     ResponseGroup getGroup(Long groupId);
 
-    List<ResponseGroup> getMyGroup(Long id);
+    List<ResponseMyGroup> getMyGroup(Long id);
 
     void updateGroup(Long adminId, RequestUpdateGroup requestUpdateGroup, Long groupId);
 

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupServiceImpl.java
@@ -106,7 +106,7 @@ public class GroupServiceImpl implements GroupService {
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ResponseMyGroup> getMyGroup(Long id) {
         return groupRepository.findAllByAdminId(id).stream()
                 .map(group -> {

--- a/src/main/java/net/skhu/wassup/app/member/api/MemberController.java
+++ b/src/main/java/net/skhu/wassup/app/member/api/MemberController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/member")
+@RequestMapping("/api/members")
 @RequiredArgsConstructor
 @Tag(name = "Member", description = "회원 관리 API")
 public class MemberController {
@@ -25,4 +25,5 @@ public class MemberController {
         memberService.save(requestMember);
         return ResponseEntity.status(CREATED).build();
     }
+
 }

--- a/src/main/java/net/skhu/wassup/app/member/domain/Member.java
+++ b/src/main/java/net/skhu/wassup/app/member/domain/Member.java
@@ -61,4 +61,8 @@ public class Member extends BaseTimeEntity {
         this.joinStatus = JoinStatus.ACCEPTED;
     }
 
+    public boolean getIsWaiting() {
+        return this.joinStatus == JoinStatus.WAITING;
+    }
+
 }

--- a/src/main/java/net/skhu/wassup/app/member/service/MemberServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/member/service/MemberServiceImpl.java
@@ -10,15 +10,18 @@ import net.skhu.wassup.app.member.domain.MemberRepository;
 import net.skhu.wassup.global.error.ErrorCode;
 import net.skhu.wassup.global.error.exception.CustomException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+
     private final GroupRepository groupRepository;
 
     @Override
+    @Transactional
     public void save(RequestMember requestMember) {
         Group group = groupRepository.findByUniqueCode(requestMember.groupCode())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GROUP));


### PR DESCRIPTION
### 내용
- #23 

- 그룹 수정 시 입력받은 필드만 업데이트합니다. 
   - 입력받지 않은 필드는 그대로 유지 할 수 있도록 `삼항 연산자`를 사용하였습니다.

- 관리자가 생성한 그룹들을 보여줍니다. 
   - 가입 대기 중인 인원 수와 가입된 인원 수를 보여줍니다.

- Swagger를 사용하여 테스트를 하던 중 파라미터로 입력받는 id가 구분이 잘 되지 않을 거라고 생각하여 어떤 파라미터 id를 입력해야하는지 명시했습니다.