### PR TITLE
[close #30] 그룹 가입 멤버 조회 기능 구현

### DIFF
--- a/src/main/java/net/skhu/wassup/app/group/api/GroupCertifyController.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/GroupCertifyController.java
@@ -1,10 +1,11 @@
-package net.skhu.wassup.app.group.api.dto;
+package net.skhu.wassup.app.group.api;
 
 import static org.springframework.http.HttpStatus.OK;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import net.skhu.wassup.app.group.api.dto.RequestVerify;
 import net.skhu.wassup.app.group.service.GroupCertifyService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/net/skhu/wassup/app/group/api/GroupController.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/GroupController.java
@@ -11,7 +11,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import net.skhu.wassup.app.group.api.dto.RequestGroup;
 import net.skhu.wassup.app.group.api.dto.RequestUpdateGroup;
-import net.skhu.wassup.app.group.api.dto.RequestVerify;
 import net.skhu.wassup.app.group.api.dto.ResponseGroup;
 import net.skhu.wassup.app.group.api.dto.ResponseMyGroup;
 import net.skhu.wassup.app.group.service.GroupService;
@@ -32,36 +31,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class GroupController {
 
     private final GroupService groupService;
-
-    @PostMapping("check")
-    @Operation(
-            summary = "그룹 이름 중복 확인",
-            description = "그룹 이름 중복을 확인합니다."
-    )
-    public ResponseEntity<Boolean> checkGroupName(@RequestParam String groupName) {
-        return ResponseEntity.status(OK).body(groupService.isDuplicateName(groupName));
-    }
-
-    @PostMapping("certification")
-    @Operation(
-            summary = "그룹 이메일 인증",
-            description = "그룹 이메일 인증을 진행합니다."
-    )
-    public ResponseEntity<Void> certification(@RequestParam String email) {
-        groupService.certification(email);
-
-        return ResponseEntity.status(OK).build();
-    }
-
-    @PostMapping("verify")
-    @Operation(
-            summary = "그룹 이메일 인증 확인",
-            description = "그룹 이메일 인증을 확인합니다."
-    )
-    public ResponseEntity<Boolean> verify(@RequestBody RequestVerify requestVerify) {
-        return ResponseEntity.status(OK)
-                .body(groupService.verify(requestVerify.email(), requestVerify.inputCertificationCode()));
-    }
 
     @PostMapping
     @Operation(

--- a/src/main/java/net/skhu/wassup/app/group/api/GroupController.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/GroupController.java
@@ -14,6 +14,7 @@ import net.skhu.wassup.app.group.api.dto.RequestUpdateGroup;
 import net.skhu.wassup.app.group.api.dto.ResponseGroup;
 import net.skhu.wassup.app.group.api.dto.ResponseMyGroup;
 import net.skhu.wassup.app.group.service.GroupService;
+import net.skhu.wassup.app.member.api.dto.ResponseMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,7 +40,7 @@ public class GroupController {
     )
     public ResponseEntity<Void> createGroup(Principal principal, @RequestBody RequestGroup requestGroup) {
         Long id = Long.parseLong(principal.getName());
-        groupService.save(id, requestGroup);
+        groupService.saveGroup(id, requestGroup);
         return ResponseEntity.status(CREATED).build();
     }
 
@@ -60,7 +61,20 @@ public class GroupController {
     )
     public ResponseEntity<List<ResponseMyGroup>> getMyGroup(Principal principal) {
         Long id = Long.parseLong(principal.getName());
-        return ResponseEntity.status(OK).body(groupService.getMyGroup(id));
+        return ResponseEntity.status(OK).body(groupService.getMyGroups(id));
+    }
+
+    @GetMapping("members")
+    @Operation(
+            summary = "그룹 멤버 조회",
+            description = "그룹 멤버를 조회합니다."
+    )
+    @Parameter(name = "id", description = "그룹 ID", required = true)
+    @Parameter(name = "type", description = "멤버 타입 (waiting or accepted or null)")
+    public ResponseEntity<List<ResponseMember>> getMemberList(Principal principal, @RequestParam Long id,
+                                                              @RequestParam String type) {
+        Long adminId = Long.parseLong(principal.getName());
+        return ResponseEntity.status(OK).body(groupService.getMemberList(adminId, id, type));
     }
 
     @PutMapping

--- a/src/main/java/net/skhu/wassup/app/group/api/GroupInviteController.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/GroupInviteController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/groups/invite")
+@RequestMapping("api/groups")
 @Tag(name = "Group Invite Controller", description = "그룹 초대 관련 API")
 public class GroupInviteController {
 

--- a/src/main/java/net/skhu/wassup/app/group/api/GroupInviteController.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/GroupInviteController.java
@@ -30,8 +30,11 @@ public class GroupInviteController {
             description = "그룹 초대를 진행합니다."
     )
     @Parameter(name = "id", description = "그룹 ID", required = true)
-    public ResponseEntity<Void> send(Long id, @RequestBody RequestInviteGroup requestInviteGroup) {
-        groupInviteService.send(id, requestInviteGroup);
+    public ResponseEntity<Void> send(Principal principal, @RequestParam Long id,
+                                     @RequestBody RequestInviteGroup requestInviteGroup) {
+        Long adminId = Long.parseLong(principal.getName());
+
+        groupInviteService.send(adminId, id, requestInviteGroup);
 
         return ResponseEntity.status(OK).build();
     }
@@ -44,6 +47,7 @@ public class GroupInviteController {
     @Parameter(name = "id", description = "멤버 ID", required = true)
     public ResponseEntity<Void> accept(Principal principal, @RequestParam Long id) {
         Long adminId = Long.parseLong(principal.getName());
+
         groupInviteService.accept(adminId, id);
 
         return ResponseEntity.status(OK).build();
@@ -57,6 +61,7 @@ public class GroupInviteController {
     @Parameter(name = "id", description = "멤버 ID", required = true)
     public ResponseEntity<Void> reject(Principal principal, @RequestParam Long id) {
         Long adminId = Long.parseLong(principal.getName());
+
         groupInviteService.reject(adminId, id);
 
         return ResponseEntity.status(OK).build();

--- a/src/main/java/net/skhu/wassup/app/group/api/dto/GroupCertifyController.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/dto/GroupCertifyController.java
@@ -1,0 +1,54 @@
+package net.skhu.wassup.app.group.api.dto;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import net.skhu.wassup.app.group.service.GroupCertifyService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/groups")
+@Tag(name = "Group Certify Controller", description = "그룹 인증 관련 API")
+public class GroupCertifyController {
+
+    private final GroupCertifyService groupCertifyService;
+
+    @PostMapping("check")
+    @Operation(
+            summary = "그룹 이름 중복 확인",
+            description = "그룹 이름 중복을 확인합니다."
+    )
+    public ResponseEntity<Boolean> checkGroupName(@RequestParam String groupName) {
+        return ResponseEntity.status(OK).body(groupCertifyService.isDuplicateName(groupName));
+    }
+
+    @PostMapping("certification")
+    @Operation(
+            summary = "그룹 이메일 인증",
+            description = "그룹 이메일 인증을 진행합니다."
+    )
+    public ResponseEntity<Void> certification(@RequestParam String email) {
+        groupCertifyService.certification(email);
+
+        return ResponseEntity.status(OK).build();
+    }
+
+    @PostMapping("verify")
+    @Operation(
+            summary = "그룹 이메일 인증 확인",
+            description = "그룹 이메일 인증을 확인합니다."
+    )
+    public ResponseEntity<Boolean> verify(@RequestBody RequestVerify requestVerify) {
+        return ResponseEntity.status(OK)
+                .body(groupCertifyService.verify(requestVerify.email(), requestVerify.inputCertificationCode()));
+    }
+
+}

--- a/src/main/java/net/skhu/wassup/app/group/domain/GroupRepository.java
+++ b/src/main/java/net/skhu/wassup/app/group/domain/GroupRepository.java
@@ -1,12 +1,15 @@
 package net.skhu.wassup.app.group.domain;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.Collection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     boolean existsGroupByName(String groupName);
+
     boolean existsGroupByUniqueCode(String code);
+
     Optional<Group> findByUniqueCode(String code);
-    Collection<Group> findAllByAdminId(Long id);
+
+    List<Group> findAllByAdminId(Long id);
 }

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupCertifyService.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupCertifyService.java
@@ -1,0 +1,11 @@
+package net.skhu.wassup.app.group.service;
+
+public interface GroupCertifyService {
+
+    boolean isDuplicateName(String groupName);
+
+    void certification(String email);
+
+    boolean verify(String email, String inputCode);
+
+}

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupCertifyServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupCertifyServiceImpl.java
@@ -1,0 +1,54 @@
+package net.skhu.wassup.app.group.service;
+
+import static net.skhu.wassup.global.error.ErrorCode.INVALID_EMAIL;
+import static net.skhu.wassup.global.error.ErrorCode.NOT_MATCH_CERTIFICATION_CODE;
+
+import lombok.RequiredArgsConstructor;
+import net.skhu.wassup.app.certification.CertificationCodeService;
+import net.skhu.wassup.app.group.domain.GroupRepository;
+import net.skhu.wassup.global.error.exception.CustomException;
+import net.skhu.wassup.global.message.EmailMessageSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GroupCertifyServiceImpl implements GroupCertifyService {
+
+    private static final String EMAIL_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
+
+    private final CertificationCodeService certificationCodeService;
+
+    private final EmailMessageSender emailMessageSender;
+
+    private final GroupRepository groupRepository;
+
+    @Override
+    public boolean isDuplicateName(String groupName) {
+        return groupRepository.existsGroupByName(groupName);
+    }
+
+    @Override
+    public void certification(String email) {
+        String certificationCode = certificationCodeService.getCertificationCode(email);
+
+        if (!email.matches(EMAIL_REGEX)) {
+            throw new CustomException(INVALID_EMAIL);
+        }
+
+        emailMessageSender.send(email, "Wassup 인증번호", certificationCode);
+    }
+
+    @Override
+    public boolean verify(String email, String inputCode) {
+        String certificationCode = certificationCodeService.getCertificationCode(email);
+
+        if (!certificationCode.equals(inputCode)) {
+            throw new CustomException(NOT_MATCH_CERTIFICATION_CODE);
+        }
+
+        certificationCodeService.deleteCertificationCode(email);
+
+        return true;
+    }
+
+}

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupInviteService.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupInviteService.java
@@ -4,7 +4,7 @@ import net.skhu.wassup.app.group.api.dto.RequestInviteGroup;
 
 public interface GroupInviteService {
 
-    void send(Long groupId, RequestInviteGroup requestInviteGroup);
+    void send(Long adminId, Long groupId, RequestInviteGroup requestInviteGroup);
 
     void accept(Long adminId, Long memberId);
 

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupInviteServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupInviteServiceImpl.java
@@ -1,6 +1,8 @@
 package net.skhu.wassup.app.group.service;
 
+import static net.skhu.wassup.global.error.ErrorCode.NOT_FOUND_GROUP;
 import static net.skhu.wassup.global.error.ErrorCode.NOT_FOUND_MEMBER;
+import static net.skhu.wassup.global.error.ErrorCode.UNAUTHORIZED_ADMIN;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -9,18 +11,13 @@ import net.skhu.wassup.app.group.domain.Group;
 import net.skhu.wassup.app.group.domain.GroupRepository;
 import net.skhu.wassup.app.member.domain.Member;
 import net.skhu.wassup.app.member.domain.MemberRepository;
-import net.skhu.wassup.global.error.ErrorCode;
 import net.skhu.wassup.global.error.exception.CustomException;
 import net.skhu.wassup.global.message.SMSMessageSender;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class GroupInviteServiceImpl implements GroupInviteService {
-
-    private static final Logger log = LoggerFactory.getLogger(GroupInviteServiceImpl.class);
 
     private final SMSMessageSender smsMessageSender;
 
@@ -30,16 +27,16 @@ public class GroupInviteServiceImpl implements GroupInviteService {
 
     @Override
     @Transactional
-    public void send(Long groupId, RequestInviteGroup requestInviteGroup) {
+    public void send(Long adminId, Long groupId, RequestInviteGroup requestInviteGroup) {
         Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GROUP));
+                .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
+
+        validateAdmin(adminId, group);
 
         String code = group.getUniqueCode();
         String message = group.getName() + "/n" + requestInviteGroup.link() + "\n 초대 코드 : " + code;
 
         smsMessageSender.send(requestInviteGroup.phoneNumber(), "Wassup 초대 코드를 아래 링크에 입력해주세요.", message);
-
-        log.info("그룹 초대 코드 전송: Group={}, Phone={}, Code={}", group.getName(), requestInviteGroup.phoneNumber(), code);
     }
 
     @Override
@@ -48,12 +45,10 @@ public class GroupInviteServiceImpl implements GroupInviteService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
 
-        Long groupId = member.getGroup().getId();
-        currentUserIsAdmin(id, groupId);
+        Group group = member.getGroup();
+        validateAdmin(id, group);
 
         member.accept();
-
-        log.info("그룹 초대 수락: Member={}", memberId);
     }
 
     @Override
@@ -62,20 +57,15 @@ public class GroupInviteServiceImpl implements GroupInviteService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
 
-        Long groupId = member.getGroup().getId();
-        currentUserIsAdmin(id, groupId);
+        Group group = member.getGroup();
+        validateAdmin(id, group);
 
         memberRepository.deleteById(memberId);
-
-        log.info("그룹 초대 거절: Member={}", memberId);
     }
 
-    private void currentUserIsAdmin(Long id, Long groupId) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GROUP));
-
+    private void validateAdmin(Long id, Group group) {
         if (!group.getAdmin().getId().equals(id)) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED_ADMIN);
+            throw new CustomException(UNAUTHORIZED_ADMIN);
         }
     }
 

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupService.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupService.java
@@ -8,12 +8,6 @@ import net.skhu.wassup.app.group.api.dto.ResponseMyGroup;
 
 public interface GroupService {
 
-    boolean isDuplicateName(String groupName);
-
-    void certification(String email);
-
-    boolean verify(String email, String inputCode);
-
     void save(Long adminId, RequestGroup requestGroup);
 
     ResponseGroup getGroup(Long groupId);

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupService.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupService.java
@@ -5,14 +5,17 @@ import net.skhu.wassup.app.group.api.dto.RequestGroup;
 import net.skhu.wassup.app.group.api.dto.RequestUpdateGroup;
 import net.skhu.wassup.app.group.api.dto.ResponseGroup;
 import net.skhu.wassup.app.group.api.dto.ResponseMyGroup;
+import net.skhu.wassup.app.member.api.dto.ResponseMember;
 
 public interface GroupService {
 
-    void save(Long adminId, RequestGroup requestGroup);
+    void saveGroup(Long adminId, RequestGroup requestGroup);
 
     ResponseGroup getGroup(Long groupId);
 
-    List<ResponseMyGroup> getMyGroup(Long id);
+    List<ResponseMyGroup> getMyGroups(Long id);
+
+    List<ResponseMember> getMemberList(Long adminId, Long groupId, String type);
 
     void updateGroup(Long adminId, RequestUpdateGroup requestUpdateGroup, Long groupId);
 

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupServiceImpl.java
@@ -1,9 +1,7 @@
 package net.skhu.wassup.app.group.service;
 
-import static net.skhu.wassup.global.error.ErrorCode.INVALID_EMAIL;
 import static net.skhu.wassup.global.error.ErrorCode.NOT_FOUND_ADMIN;
 import static net.skhu.wassup.global.error.ErrorCode.NOT_FOUND_GROUP;
-import static net.skhu.wassup.global.error.ErrorCode.NOT_MATCH_CERTIFICATION_CODE;
 import static net.skhu.wassup.global.error.ErrorCode.UNAUTHORIZED_ADMIN;
 
 import java.util.List;
@@ -11,7 +9,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import net.skhu.wassup.app.admin.domain.Admin;
 import net.skhu.wassup.app.admin.domain.AdminRepository;
-import net.skhu.wassup.app.certification.CertificationCodeService;
 import net.skhu.wassup.app.certification.GroupUniqueCodeService;
 import net.skhu.wassup.app.group.api.dto.RequestGroup;
 import net.skhu.wassup.app.group.api.dto.RequestUpdateGroup;
@@ -21,7 +18,6 @@ import net.skhu.wassup.app.group.domain.Group;
 import net.skhu.wassup.app.group.domain.GroupRepository;
 import net.skhu.wassup.app.member.domain.Member;
 import net.skhu.wassup.global.error.exception.CustomException;
-import net.skhu.wassup.global.message.EmailMessageSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,46 +25,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GroupServiceImpl implements GroupService {
 
-    private static final String EMAIL_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
 
     private final GroupRepository groupRepository;
 
-    private final CertificationCodeService certificationCodeService;
-
     private final GroupUniqueCodeService groupUniqueCodeService;
 
-    private final EmailMessageSender emailMessageSender;
 
     private final AdminRepository adminRepository;
-
-    @Override
-    public boolean isDuplicateName(String groupName) {
-        return groupRepository.existsGroupByName(groupName);
-    }
-
-    @Override
-    public void certification(String email) {
-        String certificationCode = certificationCodeService.getCertificationCode(email);
-
-        if (!email.matches(EMAIL_REGEX)) {
-            throw new CustomException(INVALID_EMAIL);
-        }
-
-        emailMessageSender.send(email, "Wassup 인증번호", certificationCode);
-    }
-
-    @Override
-    public boolean verify(String email, String inputCode) {
-        String certificationCode = certificationCodeService.getCertificationCode(email);
-
-        if (!certificationCode.equals(inputCode)) {
-            throw new CustomException(NOT_MATCH_CERTIFICATION_CODE);
-        }
-
-        certificationCodeService.deleteCertificationCode(email);
-
-        return true;
-    }
 
     @Override
     @Transactional

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupServiceImpl.java
@@ -145,8 +145,8 @@ public class GroupServiceImpl implements GroupService {
         return ResponseMember.builder()
                 .id(member.getId())
                 .name(member.getName())
-                .address(member.getAddress())
                 .phoneNumber(member.getPhoneNumber())
+                .birth(member.getBirth())
                 .specifics(member.getSpecifics())
                 .build();
     }

--- a/src/main/java/net/skhu/wassup/app/member/api/MemberController.java
+++ b/src/main/java/net/skhu/wassup/app/member/api/MemberController.java
@@ -1,15 +1,21 @@
 package net.skhu.wassup.app.member.api;
 
+import static javax.security.auth.callback.ConfirmationCallback.OK;
 import static org.springframework.http.HttpStatus.CREATED;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.skhu.wassup.app.member.api.dto.RequestMember;
+import net.skhu.wassup.app.member.api.dto.ResponseMember;
 import net.skhu.wassup.app.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,9 +27,23 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("join")
+    @Operation(
+            summary = "가입 요청",
+            description = "그룹에 가입을 요청합니다"
+    )
     public ResponseEntity<Void> join(@RequestBody RequestMember requestMember) {
         memberService.save(requestMember);
         return ResponseEntity.status(CREATED).build();
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "멤버 조회",
+            description = "멤버를 조회합니다"
+    )
+    @Parameter(name = "id", description = "멤버 ID")
+    public ResponseEntity<ResponseMember> findById(@RequestParam Long id) {
+        return ResponseEntity.status(OK).body(memberService.getMember(id));
     }
 
 }

--- a/src/main/java/net/skhu/wassup/app/member/api/MemberController.java
+++ b/src/main/java/net/skhu/wassup/app/member/api/MemberController.java
@@ -1,7 +1,6 @@
 package net.skhu.wassup.app.member.api;
 
-import static javax.security.auth.callback.ConfirmationCallback.OK;
-import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
-@Tag(name = "Member", description = "회원 관리 API")
+@Tag(name = "Member Controller", description = "회원 관련 API")
 public class MemberController {
 
     private final MemberService memberService;
@@ -32,8 +31,8 @@ public class MemberController {
             description = "그룹에 가입을 요청합니다"
     )
     public ResponseEntity<Void> join(@RequestBody RequestMember requestMember) {
-        memberService.save(requestMember);
-        return ResponseEntity.status(CREATED).build();
+        memberService.saveMember(requestMember);
+        return ResponseEntity.status(OK).build();
     }
 
     @GetMapping

--- a/src/main/java/net/skhu/wassup/app/member/api/dto/RequestMember.java
+++ b/src/main/java/net/skhu/wassup/app/member/api/dto/RequestMember.java
@@ -10,13 +10,13 @@ public record RequestMember(
         @NotBlank(message = "이름을 입력해주세요.")
         String name,
 
-        @Schema(description = "주소")
-        @NotBlank(message = "주소를 입력해주세요.")
-        String address,
-
         @Schema(description = "전화번호")
         @NotBlank(message = "전화번호를 입력해주세요.")
         String phoneNumber,
+
+        @Schema(description = "생년월일")
+        @NotBlank(message = "생년월일을 입력해주세요.")
+        String birth,
 
         @Schema(description = "특이사항")
         String specifics,

--- a/src/main/java/net/skhu/wassup/app/member/api/dto/ResponseMember.java
+++ b/src/main/java/net/skhu/wassup/app/member/api/dto/ResponseMember.java
@@ -1,0 +1,25 @@
+package net.skhu.wassup.app.member.api.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "멤버 정보 조회")
+public record ResponseMember(
+
+        @Schema(description = "멤버 ID")
+        Long id,
+
+        @Schema(description = "이름")
+        String name,
+
+        @Schema(description = "주소")
+        String address,
+
+        @Schema(description = "전화번호")
+        String phoneNumber,
+
+        @Schema(description = "특이사항")
+        String specifics) {
+
+}

--- a/src/main/java/net/skhu/wassup/app/member/api/dto/ResponseMember.java
+++ b/src/main/java/net/skhu/wassup/app/member/api/dto/ResponseMember.java
@@ -13,11 +13,11 @@ public record ResponseMember(
         @Schema(description = "이름")
         String name,
 
-        @Schema(description = "주소")
-        String address,
-
         @Schema(description = "전화번호")
         String phoneNumber,
+
+        @Schema(description = "생년월일")
+        String birth,
 
         @Schema(description = "특이사항")
         String specifics) {

--- a/src/main/java/net/skhu/wassup/app/member/domain/Member.java
+++ b/src/main/java/net/skhu/wassup/app/member/domain/Member.java
@@ -38,8 +38,8 @@ public class Member extends BaseTimeEntity {
     @Column(name = "phone_number", nullable = false)
     private String phoneNumber;
 
-    @Column(name = "address", nullable = false)
-    private String address;
+    @Column(name = "birth", nullable = false)
+    private String birth;
 
     @Column(name = "specifics")
     private String specifics;
@@ -48,11 +48,12 @@ public class Member extends BaseTimeEntity {
     private JoinStatus joinStatus;
 
     @Builder
-    public Member(Group group, String name, String phoneNumber, String address, String specifics, JoinStatus joinStatus) {
+    public Member(Group group, String name, String phoneNumber, String birth, String specifics,
+                  JoinStatus joinStatus) {
         this.group = group;
         this.name = name;
         this.phoneNumber = phoneNumber;
-        this.address = address;
+        this.birth = birth;
         this.specifics = specifics;
         this.joinStatus = joinStatus;
     }

--- a/src/main/java/net/skhu/wassup/app/member/service/MemberService.java
+++ b/src/main/java/net/skhu/wassup/app/member/service/MemberService.java
@@ -1,7 +1,12 @@
 package net.skhu.wassup.app.member.service;
 
 import net.skhu.wassup.app.member.api.dto.RequestMember;
+import net.skhu.wassup.app.member.api.dto.ResponseMember;
 
 public interface MemberService {
+
     void save(RequestMember requestMember);
+
+    ResponseMember getMember(Long id);
+
 }

--- a/src/main/java/net/skhu/wassup/app/member/service/MemberService.java
+++ b/src/main/java/net/skhu/wassup/app/member/service/MemberService.java
@@ -5,7 +5,7 @@ import net.skhu.wassup.app.member.api.dto.ResponseMember;
 
 public interface MemberService {
 
-    void save(RequestMember requestMember);
+    void saveMember(RequestMember requestMember);
 
     ResponseMember getMember(Long id);
 

--- a/src/main/java/net/skhu/wassup/app/member/service/MemberServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/member/service/MemberServiceImpl.java
@@ -1,9 +1,12 @@
 package net.skhu.wassup.app.member.service;
 
+import static net.skhu.wassup.global.error.ErrorCode.NOT_FOUND_MEMBER;
+
 import lombok.RequiredArgsConstructor;
 import net.skhu.wassup.app.group.domain.Group;
 import net.skhu.wassup.app.group.domain.GroupRepository;
 import net.skhu.wassup.app.member.api.dto.RequestMember;
+import net.skhu.wassup.app.member.api.dto.ResponseMember;
 import net.skhu.wassup.app.member.domain.JoinStatus;
 import net.skhu.wassup.app.member.domain.Member;
 import net.skhu.wassup.app.member.domain.MemberRepository;
@@ -34,6 +37,19 @@ public class MemberServiceImpl implements MemberService {
                 .joinStatus(JoinStatus.WAITING)
                 .group(group)
                 .build());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ResponseMember getMember(Long id) {
+        return memberRepository.findById(id)
+                .map(member -> ResponseMember.builder()
+                        .name(member.getName())
+                        .address(member.getAddress())
+                        .phoneNumber(member.getPhoneNumber())
+                        .specifics(member.getSpecifics())
+                        .build())
+                .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
     }
 
 }

--- a/src/main/java/net/skhu/wassup/app/member/service/MemberServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/member/service/MemberServiceImpl.java
@@ -25,14 +25,14 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public void save(RequestMember requestMember) {
+    public void saveMember(RequestMember requestMember) {
         Group group = groupRepository.findByUniqueCode(requestMember.groupCode())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_GROUP));
 
         memberRepository.save(Member.builder()
                 .name(requestMember.name())
                 .phoneNumber(requestMember.phoneNumber())
-                .address(requestMember.address())
+                .birth(requestMember.birth())
                 .specifics(requestMember.specifics())
                 .joinStatus(JoinStatus.WAITING)
                 .group(group)
@@ -44,9 +44,10 @@ public class MemberServiceImpl implements MemberService {
     public ResponseMember getMember(Long id) {
         return memberRepository.findById(id)
                 .map(member -> ResponseMember.builder()
+                        .id(member.getId())
                         .name(member.getName())
-                        .address(member.getAddress())
                         .phoneNumber(member.getPhoneNumber())
+                        .birth(member.getBirth())
                         .specifics(member.getSpecifics())
                         .build())
                 .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));


### PR DESCRIPTION
### 내용
- #30 
- 그룹 서비스 메소드를 분리하여 가독성을 높였습니다.
- 각 메소드가 어떤 역할을 하는 지 정확히 명시하기 위해 메소드 명을 수정하였습니다.
- 그룹에 요청한 멤버를 조회할 때 `type(waiting, accepted, null)`을 필터링하여 해당된 멤버만 조회가 가능합니다.