### PR TITLE
[#39] feat: DB 더미데이터 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,8 @@ spring:
   sql:
     init:
       mode: always
+      data-locations: classpath*:database/data.sql
+      platform: MySQL
 
   mail:
     host: ${MAIL_HOST}

--- a/src/main/resources/database/data.sql
+++ b/src/main/resources/database/data.sql
@@ -1,0 +1,7 @@
+INSERT INTO admin_table (create_date, update_date, admin_account_id, name, password, phone_number)
+values ('2024-04-01 00:00:00', '2024-04-01 00:00:00', 'admin', 'admin', 'admin', 'admin');
+
+INSERT INTO group_table (create_date, group_admin_id, update_date, address, business_number, description, email,
+                         group_unique_code, image_url, name)
+values ('2024-04-01 00:00:00', '1', '2024-04-01 00:00:00', '서울시 강남구', '123-45-67890', '테스트 그룹입니다.', '123@gmail.com',
+        '12A3B4', 'groupDefault.png', '테스트그룹');


### PR DESCRIPTION
### 내용
- #39 

### 결과
- JPA의 `ddl-auto`을 개발 단계라서 `create`로 설정해놓았습니다. 이로 인해 요청이 들어와 `Cloud Run`에서 배포를 진행하게 되면 새롭게 DB를 생성하는데 이때 더미데이터를 추가해놓았기 때문에 테스트를 진행할 때 이미 완성한 기능인 회원가입과 로그인, 그룹 생성 등의 절차를 거치지 않고 바로 다른 기능을 테스트할 수 있습니다.