### PR TITLE
[close #34] 그룹 관련 기능 리팩토링

### DIFF
--- a/src/main/java/net/skhu/wassup/app/admin/api/AdminController.java
+++ b/src/main/java/net/skhu/wassup/app/admin/api/AdminController.java
@@ -61,6 +61,7 @@ public class AdminController {
         if (adminService.isDuplicateId(adminId)) {
             throw new CustomException(DUPLICATE_ADMIN_ID);
         }
+
         return ResponseEntity.status(OK).body(false);
     }
 
@@ -91,6 +92,7 @@ public class AdminController {
     )
     public ResponseEntity<ResponseAdmin> getAdmin(Principal principal) {
         Long id = Long.parseLong(principal.getName());
+
         return ResponseEntity.status(OK).body(adminService.getAdmin(id));
     }
 

--- a/src/main/java/net/skhu/wassup/app/admin/domain/Admin.java
+++ b/src/main/java/net/skhu/wassup/app/admin/domain/Admin.java
@@ -1,7 +1,7 @@
 package net.skhu.wassup.app.admin.domain;
 
 import static jakarta.persistence.CascadeType.REMOVE;
-import static jakarta.persistence.FetchType.EAGER;
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -44,7 +44,7 @@ public class Admin extends BaseTimeEntity {
     private String phoneNumber;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "admin", cascade = REMOVE, fetch = EAGER)
+    @OneToMany(mappedBy = "admin", cascade = REMOVE, fetch = LAZY)
     private List<Group> groups;
 
     @Builder

--- a/src/main/java/net/skhu/wassup/app/certification/GroupUniqueCodeService.java
+++ b/src/main/java/net/skhu/wassup/app/certification/GroupUniqueCodeService.java
@@ -1,9 +1,12 @@
 package net.skhu.wassup.app.certification;
 
+import static net.skhu.wassup.global.error.ErrorCode.DUPLICATE_GROUP_CODE;
+
 import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.skhu.wassup.app.group.domain.GroupRepository;
+import net.skhu.wassup.global.error.exception.CustomException;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -19,6 +22,7 @@ public class GroupUniqueCodeService {
 
         for (int i = 0; i < 6; i++) {
             int random = secureRandom.nextInt(2);
+
             if (random == 0) {
                 char randomChar = (char) (secureRandom.nextInt(26) + 'A');
                 codeBuilder.append(randomChar);
@@ -28,15 +32,17 @@ public class GroupUniqueCodeService {
             }
         }
         String code = codeBuilder.toString();
-        isDuplicateCode(code);
+
+        if (isDuplicateCode(code)) {
+            throw new CustomException(DUPLICATE_GROUP_CODE);
+        }
+
         log.info("그룹 고유 코드 생성: Code={}", code);
         return code;
     }
 
-    private void isDuplicateCode(String code) {
-        if (groupRepository.existsGroupByUniqueCode(code)) {
-            log.error("그룹 고유 코드 중복: Code={}", code);
-        }
+    private boolean isDuplicateCode(String code) {
+        return groupRepository.existsGroupByUniqueCode(code);
     }
 
 }

--- a/src/main/java/net/skhu/wassup/app/group/api/dto/ResponseMyGroup.java
+++ b/src/main/java/net/skhu/wassup/app/group/api/dto/ResponseMyGroup.java
@@ -11,16 +11,16 @@ public record ResponseMyGroup(
         Long id,
 
         @Schema(description = "그룹 이름")
-        String groupName,
+        String name,
 
         @Schema(description = "그룹 주소")
         String address,
 
         @Schema(description = "총 인원")
-        int totalMember,
+        Long totalMember,
 
         @Schema(description = "가입 대기중인 인원")
-        int waitingMember,
+        Long waitingMember,
 
         @Schema(description = "그룹 이미지 URL")
         String imageUrl) {

--- a/src/main/java/net/skhu/wassup/app/group/domain/Group.java
+++ b/src/main/java/net/skhu/wassup/app/group/domain/Group.java
@@ -1,6 +1,6 @@
 package net.skhu.wassup.app.group.domain;
 
-import static jakarta.persistence.FetchType.EAGER;
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -60,18 +60,21 @@ public class Group extends BaseTimeEntity {
     private String uniqueCode;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "group", fetch = EAGER)
+    @OneToMany(mappedBy = "group", fetch = LAZY)
     private List<Member> members;
 
     public void update(RequestUpdateGroup requestUpdateGroup) {
-        this.description = (requestUpdateGroup.description() != null) ? requestUpdateGroup.description() : this.description;
+        this.description =
+                (requestUpdateGroup.description() != null) ? requestUpdateGroup.description() : this.description;
         this.address = (requestUpdateGroup.address() != null) ? requestUpdateGroup.address() : this.address;
-        this.businessNumber = (requestUpdateGroup.businessNumber() != null) ? requestUpdateGroup.businessNumber() : this.businessNumber;
+        this.businessNumber = (requestUpdateGroup.businessNumber() != null) ? requestUpdateGroup.businessNumber()
+                : this.businessNumber;
         this.imageUrl = (requestUpdateGroup.imageUrl() != null) ? requestUpdateGroup.imageUrl() : this.imageUrl;
     }
 
     @Builder
-    public Group(Admin admin, String name, String description, String address, String businessNumber, String email, String imageUrl, String uniqueCode) {
+    public Group(Admin admin, String name, String description, String address, String businessNumber, String email,
+                 String imageUrl, String uniqueCode) {
         this.admin = admin;
         this.name = name;
         this.description = description;

--- a/src/main/java/net/skhu/wassup/app/group/domain/GroupRepository.java
+++ b/src/main/java/net/skhu/wassup/app/group/domain/GroupRepository.java
@@ -2,14 +2,32 @@ package net.skhu.wassup.app.group.domain;
 
 import java.util.List;
 import java.util.Optional;
+import net.skhu.wassup.app.group.api.dto.ResponseMyGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
+
     boolean existsGroupByName(String groupName);
 
     boolean existsGroupByUniqueCode(String code);
 
     Optional<Group> findByUniqueCode(String code);
 
-    List<Group> findAllByAdminId(Long id);
+    @Query(value = """
+            SELECT new net.skhu.wassup.app.group.api.dto.ResponseMyGroup(
+                g.id,
+                g.name,
+                g.address,
+                COUNT(CASE WHEN m.joinStatus = 1 THEN 1 END),
+                COUNT(CASE WHEN m.joinStatus = 0 THEN 1 END),
+                g.imageUrl)
+            FROM Group g LEFT JOIN Member m
+                ON g.id = m.group.id
+            WHERE g.admin.id = :adminId
+            GROUP BY g.id
+            """)
+    List<ResponseMyGroup> getMyGroups(@Param("adminId") Long adminId);
+
 }

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupInviteServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupInviteServiceImpl.java
@@ -31,7 +31,9 @@ public class GroupInviteServiceImpl implements GroupInviteService {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
 
-        validateAdmin(adminId, group);
+        if (isNotUserGroupAdmin(adminId, group)) {
+            throw new CustomException(UNAUTHORIZED_ADMIN);
+        }
 
         String code = group.getUniqueCode();
         String message = group.getName() + "\n\n" + requestInviteGroup.link() + "\n\n초대 코드 : " + code;
@@ -46,7 +48,10 @@ public class GroupInviteServiceImpl implements GroupInviteService {
                 .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
 
         Group group = member.getGroup();
-        validateAdmin(id, group);
+
+        if (isNotUserGroupAdmin(id, group)) {
+            throw new CustomException(UNAUTHORIZED_ADMIN);
+        }
 
         member.accept();
     }
@@ -58,15 +63,16 @@ public class GroupInviteServiceImpl implements GroupInviteService {
                 .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER));
 
         Group group = member.getGroup();
-        validateAdmin(id, group);
+
+        if (isNotUserGroupAdmin(id, group)) {
+            throw new CustomException(UNAUTHORIZED_ADMIN);
+        }
 
         memberRepository.deleteById(memberId);
     }
 
-    private void validateAdmin(Long id, Group group) {
-        if (!group.getAdmin().getId().equals(id)) {
-            throw new CustomException(UNAUTHORIZED_ADMIN);
-        }
+    private boolean isNotUserGroupAdmin(Long id, Group group) {
+        return !group.getAdmin().getId().equals(id);
     }
 
 }

--- a/src/main/java/net/skhu/wassup/app/group/service/GroupService.java
+++ b/src/main/java/net/skhu/wassup/app/group/service/GroupService.java
@@ -13,7 +13,7 @@ public interface GroupService {
 
     ResponseGroup getGroup(Long groupId);
 
-    List<ResponseMyGroup> getMyGroups(Long id);
+    List<ResponseMyGroup> getMyGroups(Long adminId);
 
     List<ResponseMember> getMemberList(Long adminId, Long groupId, String type);
 

--- a/src/main/java/net/skhu/wassup/global/error/ErrorCode.java
+++ b/src/main/java/net/skhu/wassup/global/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 
     DUPLICATE_ADMIN_ID(HttpStatus.BAD_REQUEST, "DP001", "이미 존재하는 아이디입니다."),
     DUPLICATE_GROUP_NAME(HttpStatus.BAD_REQUEST, "DP002", "이미 존재하는 그룹 이름입니다."),
+    DUPLICATE_GROUP_CODE(HttpStatus.BAD_REQUEST, "DP003", "이미 존재하는 그룹 코드입니다."),
 
     NOT_FOUND_ADMIN(HttpStatus.NOT_FOUND, "NF001", "존재하지 않는 관리자입니다."),
     NOT_FOUND_GROUP(HttpStatus.NOT_FOUND, "NF002", "그룹 정보가 존재하지 않습니다."),


### PR DESCRIPTION
### 내용
- #34

### 리뷰 답변 
> return switch 문은 처음 보는 것 같아요! 이렇게 작성하면 case 조건에 걸리자마자 바로 반환되는 것인가요? 기존 알고 있는 switch 문은 break가 없으면 아래로 계속 내려가는 것으로 알고 있어서 질문 드립니다!
- Java 12 이전의 Switch문은 case 조건마다 break문이 호출될 때까지 조건을 돌리는 불편함이 있었습니다. Java 12 이후 Switch문 case 조건에 걸리면 바로 리턴하는 방식으로 바뀌었습니다. 또한 화살표 사용이 가능해졌고, 여러가지 case를 한 번에 적을 수 있는 장점을 가지고 있습니다.

> Group 엔티티와 Admin 엔티티의 연관 관계를 지정할 때 fetch = LAZY로 지정했다면, Spring Data JPA Repository를 통해 id로 Group 엔티티 객체를 불러오고나서 Admin에 접근하려고하면 추가 쿼리가 나갈 것 같아요. 엔티티 객체로 꺼내와서 필드값을 비교하고 true/false를 알아내지 말고, 관리자 id와 그룹 id로 해당 그룹의 관리자가 맞는지 boolean 결과를 나타내는 쿼리를 만들어서 사용하면 더욱 깔끔할 것 같아요.

> Group 엔티티에 매핑된 Member 엔티티에 조회하는 코드인 group.getMembers() 여기서 fetch = LAZY로 지정했다면 추가 쿼리가 발생할 것 같아요. 처음부터 Group과 Member를 Join하고 필요한 값들을 뽑아서 쓰면 코드도 훨씬 깔끔해질 것 같아요.
- 수정했습니다! 확인 부탁드릴게요 @YehyeokBang 