### PR TITLE
[close #83] 멤버 개별 공지사항 전송 기능 구현

### DIFF
--- a/src/main/java/net/skhu/wassup/app/announcement/api/AnnouncementController.java
+++ b/src/main/java/net/skhu/wassup/app/announcement/api/AnnouncementController.java
@@ -11,6 +11,7 @@ import net.skhu.wassup.app.announcement.api.dto.ResponseAnnouncement;
 import net.skhu.wassup.app.announcement.service.AnnouncementService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,6 +50,22 @@ public class AnnouncementController {
         Long adminId = Long.parseLong(principal.getName());
 
         return ResponseEntity.ok(announcementService.getAnnouncement(adminId, id));
+    }
+
+    @PostMapping("/{memberId}")
+    @Operation(
+            summary = "멤버 개별 공지사항 전송",
+            description = "멤버 개별 공지사항을 전송합니다."
+    )
+    @Parameter(name = "groupId", description = "그룹 ID", required = true)
+    @Parameter(name = "memberId", description = "멤버 ID", required = true)
+    public ResponseEntity<Void> writeAnnouncementToMember(Principal principal, @PathVariable Long memberId,
+                                                          @RequestParam Long groupId,
+                                                          @RequestBody RequestAnnouncement requestAnnouncement) {
+        Long adminId = Long.parseLong(principal.getName());
+        announcementService.writeAnnouncementToMember(adminId, groupId, memberId, requestAnnouncement);
+
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/net/skhu/wassup/app/announcement/service/AnnouncementService.java
+++ b/src/main/java/net/skhu/wassup/app/announcement/service/AnnouncementService.java
@@ -10,4 +10,6 @@ public interface AnnouncementService {
 
     List<ResponseAnnouncement> getAnnouncement(Long id, Long groupId);
 
+    void writeAnnouncementToMember(Long id, Long groupId, Long memberId, RequestAnnouncement requestAnnouncement);
+
 }

--- a/src/main/java/net/skhu/wassup/app/announcement/service/AnnouncementServiceImpl.java
+++ b/src/main/java/net/skhu/wassup/app/announcement/service/AnnouncementServiceImpl.java
@@ -2,6 +2,7 @@ package net.skhu.wassup.app.announcement.service;
 
 import static net.skhu.wassup.app.member.domain.JoinStatus.ACCEPTED;
 import static net.skhu.wassup.global.error.ErrorCode.NOT_FOUND_GROUP;
+import static net.skhu.wassup.global.error.ErrorCode.NOT_FOUND_MEMBER;
 import static net.skhu.wassup.global.error.ErrorCode.UNAUTHORIZED_ADMIN;
 
 import java.util.List;
@@ -14,6 +15,7 @@ import net.skhu.wassup.app.announcement.domain.AnnouncementRepository;
 import net.skhu.wassup.app.group.domain.Group;
 import net.skhu.wassup.app.group.domain.GroupRepository;
 import net.skhu.wassup.app.member.domain.Member;
+import net.skhu.wassup.app.member.domain.MemberRepository;
 import net.skhu.wassup.global.error.exception.CustomException;
 import net.skhu.wassup.global.message.SMSMessageSender;
 import org.springframework.stereotype.Service;
@@ -28,7 +30,19 @@ public class AnnouncementServiceImpl implements AnnouncementService {
 
     private final AnnouncementRepository announcementRepository;
 
+    private final MemberRepository memberRepository;
+
     private final SMSMessageSender smsMessageSender;
+
+    private boolean isCheckSendStatus(String phoneNumber, String title, String content) {
+        try {
+            smsMessageSender.send(phoneNumber, title, content);
+            return true;
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return false;
+        }
+    }
 
     private boolean isMemberFailedToReceiveAnnouncement(Member member, RequestAnnouncement requestAnnouncement) {
         return member.getJoinStatus().equals(ACCEPTED) && !isCheckSendStatus(member.getPhoneNumber(),
@@ -39,16 +53,6 @@ public class AnnouncementServiceImpl implements AnnouncementService {
         return group.getMembers().stream()
                 .filter(member -> isMemberFailedToReceiveAnnouncement(member, requestAnnouncement))
                 .toList();
-    }
-
-    private boolean isCheckSendStatus(String phoneNumber, String title, String content) {
-        try {
-            smsMessageSender.send(phoneNumber, title, content);
-            return true;
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            return false;
-        }
     }
 
     private void saveAnnouncement(Group group, RequestAnnouncement requestAnnouncement) {
@@ -75,6 +79,37 @@ public class AnnouncementServiceImpl implements AnnouncementService {
         return failedMembers.stream()
                 .map(Member::toString)
                 .toList();
+    }
+
+    private boolean isNotGroupMember(Long memberId, Group group) {
+        return group.getMembers().stream()
+                .noneMatch(member -> member.getId().equals(memberId));
+    }
+
+    private String findPhoneNumber(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER))
+                .getPhoneNumber();
+    }
+
+    @Override
+    @Transactional
+    public void writeAnnouncementToMember(Long id, Long groupId, Long memberId,
+                                          RequestAnnouncement requestAnnouncement) {
+        Group group = getGroupOrThrow(groupId);
+
+        if (isNotUserGroupAdmin(id, group)) {
+            throw new CustomException(UNAUTHORIZED_ADMIN);
+        }
+
+        if (isNotGroupMember(memberId, group)) {
+            throw new CustomException(NOT_FOUND_MEMBER);
+        }
+
+        String messageTitle = String.format("[%s] %s", group.getName(), requestAnnouncement.title());
+        String phoneNumber = findPhoneNumber(memberId);
+
+        isCheckSendStatus(phoneNumber, messageTitle, requestAnnouncement.content());
     }
 
     private ResponseAnnouncement mapToResponseAnnouncement(Announcement announcement) {

--- a/src/main/java/net/skhu/wassup/global/error/ErrorCode.java
+++ b/src/main/java/net/skhu/wassup/global/error/ErrorCode.java
@@ -18,7 +18,7 @@ public enum ErrorCode {
 
     NOT_FOUND_ADMIN(HttpStatus.NOT_FOUND, "NF001", "존재하지 않는 관리자입니다."),
     NOT_FOUND_GROUP(HttpStatus.NOT_FOUND, "NF002", "그룹 정보가 존재하지 않습니다."),
-    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "NF003", "회원 정보가 존재하지 않습니다."),
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "NF003", "멤버 정보가 존재하지 않습니다."),
     NOT_FOUND_ATTENDANCE(HttpStatus.NOT_FOUND, "NF004", "출석 정보가 존재하지 않습니다."),
 
     INVALID_EMAIL(HttpStatus.BAD_REQUEST, "IV001", "이메일 형식이 올바르지 않습니다."),


### PR DESCRIPTION
### 내용
- #83 

<img width="474" alt="image" src="https://github.com/WASSUP-Project/WASSUP-Server/assets/84395062/37f24b02-4bba-4d92-82e2-d76a3bd3004d">

⭐ 개발 환경에서 메시지 전송 API 요금을 줄이기 위해 로그를 출력하는 방법으로 변경하였습니다.
